### PR TITLE
Use `OBJECT` library for `abcc_api` to ensure callback resolution during static linking

### DIFF
--- a/abcc-driver-api.cmake
+++ b/abcc-driver-api.cmake
@@ -28,7 +28,7 @@ set(abcc_api_INCS
 
 # Creating a library target containing the Anybus CompactCom API.
 # The include files are added only to keep the file and directory tree structure.
-add_library(abcc_api STATIC 
+add_library(abcc_api OBJECT 
    ${abcc_api_SRCS}
    ${abcc_api_INCS}
 )


### PR DESCRIPTION
**Description**:

This PR changes the `abcc_api` target from a `STATIC` library to an `OBJECT` library.

### Motivation

When linking against `abcc_api` as part of a larger static library (e.g., a wrapper module such as `module_hms`), the linker may discard object files from `libabcc_api.a` that contain only undefined references (e.g., to `ABCC_API_CbfUserInit`, `ABCC_CbfHandleCommandMessage`, etc.). This leads to undefined symbol errors during final application linking.

By converting `abcc_api` to an `OBJECT` library, all object files are guaranteed to be included in the parent static library that consumes them. This approach ensures that all relocation entries and references are preserved as expected in embedded firmware projects.

### Benefits

* Eliminates undefined references to ABCC callback symbols at link time.
* Simplifies integration into wrapper modules or layered CMake projects.
* Maintains full control over linking and symbol visibility at the application level.

### Notes

This change does not alter any logic or behavior in the ABCC stack itself. It only affects the build mechanics to make the library more robust in modular CMake environments.

Let me know if you’d prefer this behind a build option or need support for backward compatibility.