### PR TITLE
Add posibility to specify CMake lib type via ABCC_LIB_TYPE

### DIFF
--- a/abcc-driver-api.cmake
+++ b/abcc-driver-api.cmake
@@ -26,9 +26,15 @@ set(abcc_api_INCS
    ${ABCC_API_DIR}/src/host_objects/application_data_object.h
 )
 
+# Check if ABCC_LIB_TYPE is not already defined. ABCC_LIB_TYPE can be set in a
+# higher level CMake file to the desired library type of the Anybus CompactCom API.
+if(NOT DEFINED ABCC_LIB_TYPE)
+   set(ABCC_LIB_TYPE STATIC)
+endif()
+
 # Creating a library target containing the Anybus CompactCom API.
 # The include files are added only to keep the file and directory tree structure.
-add_library(abcc_api STATIC 
+add_library(abcc_api ${ABCC_LIB_TYPE}
    ${abcc_api_SRCS}
    ${abcc_api_INCS}
 )

--- a/abcc-driver-api.cmake
+++ b/abcc-driver-api.cmake
@@ -52,6 +52,9 @@ set(ABCC_DRIVER_INCLUDE_DIRS ${ABCC_API_INCLUDE_DIRS})
 # The directory containing the Anybus CompactCom Driver repository.
 set(ABCC_DRIVER_DIR ${ABCC_API_DIR}/abcc-driver)
 
+# The Anybus CompactCom Driver library will be of OBJECT type.
+set(ABCC_LIB_TYPE OBJECT)
+
 # Including the Anybus CompactCom Driver's CMake module file.
 include(${ABCC_DRIVER_DIR}/abcc-driver.cmake)
 


### PR DESCRIPTION
The variable ABCC_LIB_TYPE can be created in the user CMake file and set to the desired library type of the Anybus CompactCom API. If ABCC_LIB_TYPE is not defined in the user CMake file, it will take the default value of STATIC.

Note, the ABCC_LIB_TYPE variable is then reused by the Anybus CompactCom API to specify the library type of the Anybus CompactCom Driver into OBJECT.