### PR TITLE
A7077A-55 SPI: add possibility to change message fragment size at runtime

### DIFF
--- a/inc/abcc_api.h
+++ b/inc/abcc_api.h
@@ -134,7 +134,7 @@ EXTFUNC void ABCC_API_Restart( void );
 **       ABCC_ErrorCodeType
 **------------------------------------------------------------------------------
 */
-EXTFUNC ABCC_ErrorCodeType ABCC_API_NewMsgFragSize( const UINT16 iReqMsgFragSize );
+EXTFUNC ABCC_ErrorCodeType ABCC_API_SetMsgFragSize( const UINT16 iReqMsgFragSize );
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 
 /*------------------------------------------------------------------------------

--- a/inc/abcc_api.h
+++ b/inc/abcc_api.h
@@ -114,17 +114,21 @@ EXTFUNC void ABCC_API_Restart( void );
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 /*------------------------------------------------------------------------------
-** This function is used for SPI mode, only. (enabling and calling the function
-** for other operating modes has no effect.) It sets the new message frament
+** This function is used for SPI mode, only. It sets the new message fragment
 ** size for the SPI frame.
-** If the size is changed, it's used for the next SPI transaction and until
-** changed again.
+**
+** If the size is changed, the new size is used for the next SPI transaction
+** until changed again.
+**
 ** Valid range for the fragment size is ABCC_CFG_SPI_MIN_MSG_FRAG_LEN to
 ** ABCC_CFG_SPI_MAX_MSG_FRAG_LEN.
 ** Default at system startup is ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN.
+**
+** Enabling and calling the function for other operating modes than SPI has no
+** effect.
 **------------------------------------------------------------------------------
 ** Arguments:
-**       iReqMsgFragSize:   requested Size of message fragment (bytes)
+**       iReqMsgFragSize:   requested size of message fragment (bytes)
 **
 ** Returns:
 **       ABCC_ErrorCodeType

--- a/inc/abcc_api.h
+++ b/inc/abcc_api.h
@@ -112,6 +112,27 @@ EXTFUNC void ABCC_API_Shutdown( void );
 */
 EXTFUNC void ABCC_API_Restart( void );
 
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+/*------------------------------------------------------------------------------
+** This function is used for SPI mode, only. (enabling and calling the function
+** for other operating modes has no effect.) It sets the new message frament
+** size for the SPI frame.
+** If the size is changed, it's used for the next SPI transaction and until
+** changed again.
+** Valid range for the fragment size is ABCC_CFG_SPI_MIN_MSG_FRAG_LEN to
+** ABCC_CFG_SPI_MAX_MSG_FRAG_LEN.
+** Default at system startup is ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN.
+**------------------------------------------------------------------------------
+** Arguments:
+**       iReqMsgFragSize:   requested Size of message fragment (bytes)
+**
+** Returns:
+**       ABCC_ErrorCodeType
+**------------------------------------------------------------------------------
+*/
+EXTFUNC ABCC_ErrorCodeType ABCC_API_NewMsgFragSize( const UINT16 iReqMsgFragSize );
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+
 /*------------------------------------------------------------------------------
 ** Polls the current Anybus state of the CompactCom. The Anybus state is useful
 ** to determine how to act in certain situations, since it reflects the state

--- a/inc/abcc_api.h
+++ b/inc/abcc_api.h
@@ -124,8 +124,8 @@ EXTFUNC void ABCC_API_Restart( void );
 ** ABCC_CFG_SPI_MAX_MSG_FRAG_LEN.
 ** Default at system startup is ABCC_CFG_SPI_DEFAULT_MSG_FRAG_LEN.
 **
-** Enabling and calling the function for other operating modes than SPI has no
-** effect.
+** Calling the function for other operating modes than SPI has no effect on
+** communication to the CompactCom and will always return ABCC_EC_NO_ERROR.
 **------------------------------------------------------------------------------
 ** Arguments:
 **       iReqMsgFragSize:   requested size of message fragment (bytes)

--- a/src/abcc_api_handler.c
+++ b/src/abcc_api_handler.c
@@ -1029,7 +1029,7 @@ void ABCC_API_Restart( void )
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 ABCC_ErrorCodeType ABCC_API_SetMsgFragSize( const UINT16 iReqMsgFragSize )
 {
-   return( ABCC_NewMsgFragSize( iReqMsgFragSize ) );
+   return( ABCC_SetMsgFragSize( iReqMsgFragSize ) );
 }
 #endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
 

--- a/src/abcc_api_handler.c
+++ b/src/abcc_api_handler.c
@@ -1027,7 +1027,7 @@ void ABCC_API_Restart( void )
 }
 
 #if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
-ABCC_ErrorCodeType ABCC_API_NewMsgFragSize( const UINT16 iReqMsgFragSize )
+ABCC_ErrorCodeType ABCC_API_SetMsgFragSize( const UINT16 iReqMsgFragSize )
 {
    return( ABCC_NewMsgFragSize( iReqMsgFragSize ) );
 }

--- a/src/abcc_api_handler.c
+++ b/src/abcc_api_handler.c
@@ -1026,6 +1026,13 @@ void ABCC_API_Restart( void )
    appl_eAbccHandlerState = ABCC_API_RESTART;
 }
 
+#if ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+ABCC_ErrorCodeType ABCC_API_NewMsgFragSize( const UINT16 iReqMsgFragSize )
+{
+   return( ABCC_NewMsgFragSize( iReqMsgFragSize ) );
+}
+#endif // ABCC_CFG_SPI_DYNAMIC_MSG_FRAG_LEN
+
 ABP_AnbStateType ABCC_API_AnbState( void )
 {
    return( (ABP_AnbStateType)ABCC_AnbState() );


### PR DESCRIPTION
Make new driver functions to change message fragment size in SPI frames at runtime available within the API.