### PR TITLE
A7077A-86: APPD Object: add options to disable automatic swapping within API

### DIFF
--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -223,14 +223,14 @@
 **
 ** When ADI values are read, they are swapped from application byte order to
 ** network byte order, and when they are written, they are swapped from network
-** to application byte orderby the application data object handler.
-** In some use cases, a configurable swapping is needed. In this cases, the
-** defines AD_CFG_DIABLE_BYTE_SWAP_PD, AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE and
-** AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL can be used to disable value byte swapping
-** within API code according to applications needs.
+** to application byte order by the application data object handler.
+** In some use cases, configurable swapping is needed. In these cases, the
+** defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD, AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
+** and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL can be used to disable value byte
+** swapping within API code according to applications needs.
 ** ABCC_NetFormat() can be used to determine the byte order used by the network.
 **
-** AD_CFG_DIABLE_BYTE_SWAP_PD
+** AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
 ** This define disables byte swapping for the mapped process data blocks.
 **
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
@@ -238,30 +238,30 @@
 ** These messages are typically triggered by acyclic access command from the
 ** supervising PLC.
 ** This define will also disable byte swapping for min, max and default values
-** of the the ADIs.
+** of the ADIs.
 **
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 ** This define disables byte swapping for both access channels.
 ** To make code struct easier, this define will override the other two defines
 ** if set to 1.
 */ 
-#ifndef AD_CFG_DIABLE_BYTE_SWAP_PD
-   #define AD_CFG_DIABLE_BYTE_SWAP_PD         0
-#endif // !AD_CFG_DIABLE_BYTE_SWAP_PD
+#ifndef AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
+   #define AD_CFG_DISABLE_ADI_BYTE_SWAP_PD         0
+#endif // !AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
 
-#ifndef AD_CFG_DIABLE_BYTE_SWAP_MESSAGE
-   #define AD_CFG_DIABLE_BYTE_SWAP_MESSAGE    0
-#endif // !AD_CFG_DIABLE_BYTE_SWAP_MESSAGE
+#ifndef AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
+   #define AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE    0
+#endif // !AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
 
-#ifndef AD_CFG_DIABLE_BYTE_SWAP_TOTAL
-   #define AD_CFG_DIABLE_BYTE_SWAP_TOTAL      0
-#endif // !AD_CFG_DIABLE_BYTE_SWAP_TOTAL
+#ifndef AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
+   #define AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL      0
+#endif // !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 
-#if AD_CFG_DIABLE_BYTE_SWAP_TOTAL
-   #undef AD_CFG_DIABLE_BYTE_SWAP_PD
-   #define AD_CFG_DIABLE_BYTE_SWAP_PD         0
-   #undef AD_CFG_DIABLE_BYTE_SWAP_MESSAGE
-   #define AD_CFG_DIABLE_BYTE_SWAP_MESSAGE    0
-#endif // AD_CFG_DIABLE_BYTE_SWAP_TOTAL
+#if AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
+   #undef AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
+   #define AD_CFG_DISABLE_ADI_BYTE_SWAP_PD         0
+   #undef AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
+   #define AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE    0
+#endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 
 #endif

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -249,7 +249,7 @@
 **       differ from application byte order).
 **       To handle the range check within application, transparent set callbacks
 **       (enabled by ABCC_CFG_ADI_TRANS_SET_CALLBACK_ENABLED) can be used.
-**       The corresponding warning will be reported as plattform-independant
+**       The corresponding warning will be reported as platform-independant
 **       compiler error but can be suppressed by defining
 **       AD_CFG_OVERRIDE_WARNING_RANGE_CHECK.
 ** 

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -219,7 +219,7 @@
 #endif
 
 /*
-** Swapping of data values
+** ADI Data Value Swapping
 **
 ** By default, ADI values are byte-swapped between application and network byte
 ** order by the application data object handler. However, some use cases require

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -218,4 +218,46 @@
    #define AD_IA_MIN_MAX_DEFAULT_ENABLE            0
 #endif
 
+/*
+** Swapping of data values
+**
+** When ADI values are read, they are swapped from application byte order to
+** network byte order, and when they are written, they are swapped from network
+** to application byte orderby the application data object handler.
+** In some use cases, a configurable swapping is needed. In this cases, the
+** defines AD_CFG_DIABLE_BYTE_SWAP_PD, AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE and
+** AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL can be used to disable value byte swapping
+** within API code according to applications needs.
+** ABCC_NetFormat() can be used to determine the byte order used by the network.
+**
+** AD_CFG_DIABLE_BYTE_SWAP_PD
+** This define disables byte swapping for the mapped process data blocks.
+**
+** AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
+** This define disables byte swapping for messages accessing the ADI values.
+** These messages are typically triggered by acyclic access command from the
+** supervising PLC.
+**
+** AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
+** This define disables byte swapping for both access channels.
+*/ 
+#ifndef AD_CFG_DIABLE_BYTE_SWAP_PD
+   #define AD_CFG_DIABLE_BYTE_SWAP_PD         0
+#endif // !AD_CFG_DIABLE_BYTE_SWAP_PD
+
+#ifndef AD_CFG_DIABLE_BYTE_SWAP_MESSAGE
+   #define AD_CFG_DIABLE_BYTE_SWAP_MESSAGE    0
+#endif // !AD_CFG_DIABLE_BYTE_SWAP_MESSAGE
+
+#ifndef AD_CFG_DIABLE_BYTE_SWAP_TOTAL
+   #define AD_CFG_DIABLE_BYTE_SWAP_TOTAL      0
+#endif // !AD_CFG_DIABLE_BYTE_SWAP_TOTAL
+
+#if AD_CFG_DIABLE_BYTE_SWAP_TOTAL
+   #undef AD_CFG_DIABLE_BYTE_SWAP_PD
+   #define AD_CFG_DIABLE_BYTE_SWAP_PD         0
+   #undef AD_CFG_DIABLE_BYTE_SWAP_MESSAGE
+   #define AD_CFG_DIABLE_BYTE_SWAP_MESSAGE    0
+#endif // AD_CFG_DIABLE_BYTE_SWAP_TOTAL
+
 #endif

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -221,9 +221,9 @@
 /*
 ** Swapping of data values
 **
-** When ADI values are read, they are swapped from application byte order to
-** network byte order, and when they are written, they are swapped from network
-** to application byte order by the application data object handler.
+** When ADI values are read/written, they are normally swapped between
+** application byte order and network byte order by the application data object
+** handler.
 ** In some use cases, configurable swapping is needed. In these cases, the
 ** defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD, AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
 ** and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL can be used to disable value byte
@@ -235,7 +235,7 @@
 **
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
 ** This define disables byte swapping for messages accessing the ADI values.
-** These messages are typically triggered by acyclic access command from the
+** These messages are typically triggered by an acyclic access command from the
 ** supervising PLC.
 ** This define will also disable byte swapping for min, max and default values
 ** of the ADIs.

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -227,7 +227,7 @@
 ** In some use cases, configurable swapping is needed. In these cases, the
 ** defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD, AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
 ** and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL can be used to disable value byte
-** swapping within API code according to applications needs.
+** swapping within the API code according to application's needs.
 ** ABCC_NetFormat() can be used to determine the byte order used by the network.
 **
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
@@ -242,8 +242,8 @@
 **
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 ** This define disables byte swapping for both access channels.
-** To make code struct easier, this define will override the other two defines
-** if set to 1.
+** To make the code structure simpler, this define will override the other two
+** defines if set to 1.
 */ 
 #ifndef AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
    #define AD_CFG_DISABLE_ADI_BYTE_SWAP_PD         0

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -221,31 +221,26 @@
 /*
 ** Swapping of data values
 **
-** When ADI values are read/written, they are normally swapped between
-** application byte order and network byte order by the application data object
-** handler.
-** In some use cases, configurable swapping is needed. In these cases, the
-** defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD, AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
-** and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL can be used to disable value byte
-** swapping within the API code according to application's needs. When swapping
-** is disabled, values are copied without endian conversion; ensure that stored
-** ADI values/properties match the expected on-wire byte order, which can be
-** determined by using ABCC_NetFormat().
+** By default, ADI values are byte-swapped between application and network byte
+** order by the application data object handler. However, some use cases require
+** swapping to be configurable.
+**
+** The following defines allow disabling this swap for specific access channels.
+** When disabled, values are copied as-is (no endian conversion);
+** stored ADI values must then already match the desired on-wire byte order.
+** The default byte order can be determined by using ABCC_NetFormat().
 **
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
-** This define disables byte swapping for the mapped process data blocks.
-**
+**   Disables swapping for mapped process data blocks.
+** 
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
-** This define disables byte swapping for messages accessing the ADI values.
-** These messages are typically triggered by an acyclic access command from the
-** supervising PLC.
-** This define will also disable byte swapping for min, max and default values
-** of the ADIs.
-**
+**   Disables swapping for message-based ADI access (typically triggered by an
+**   acyclic command from the supervising PLC). Also covers min, max, and
+**   default values of the ADIs.
+** 
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
-** This define disables byte swapping for both access channels.
-** To make the code structure simpler, this define will override the other two
-** defines if set to 1.
+**   Disables swapping for both channels at once. Overrides the other two
+**   defines when set (simplifies configuration & reduces code size).
 */
 #ifndef AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
    #define AD_CFG_DISABLE_ADI_BYTE_SWAP_PD         0

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -227,9 +227,9 @@
 ** In some use cases, configurable swapping is needed. In these cases, the
 ** defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD, AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
 ** and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL can be used to disable value byte
-** swapping within the API code according to application's needs.When swapping
+** swapping within the API code according to application's needs. When swapping
 ** is disabled, values are copied without endian conversion; ensure that stored
-** ADI values/properties match the expected on-wire byte order, wich can be
+** ADI values/properties match the expected on-wire byte order, which can be
 ** determined by using ABCC_NetFormat().
 **
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_PD

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -237,9 +237,13 @@
 ** This define disables byte swapping for messages accessing the ADI values.
 ** These messages are typically triggered by acyclic access command from the
 ** supervising PLC.
+** This define will also disable byte swapping for min, max and default values
+** of the the ADIs.
 **
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 ** This define disables byte swapping for both access channels.
+** To make code struct easier, this define will override the other two defines
+** if set to 1.
 */ 
 #ifndef AD_CFG_DIABLE_BYTE_SWAP_PD
    #define AD_CFG_DIABLE_BYTE_SWAP_PD         0

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -227,8 +227,10 @@
 ** In some use cases, configurable swapping is needed. In these cases, the
 ** defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD, AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
 ** and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL can be used to disable value byte
-** swapping within the API code according to application's needs.
-** ABCC_NetFormat() can be used to determine the byte order used by the network.
+** swapping within the API code according to application's needs.When swapping
+** is disabled, values are copied without endian conversion; ensure that stored
+** ADI values/properties match the expected on-wire byte order, wich can be
+** determined by using ABCC_NetFormat().
 **
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
 ** This define disables byte swapping for the mapped process data blocks.

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -246,7 +246,7 @@
 ** This define disables byte swapping for both access channels.
 ** To make the code structure simpler, this define will override the other two
 ** defines if set to 1.
-*/ 
+*/
 #ifndef AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
    #define AD_CFG_DISABLE_ADI_BYTE_SWAP_PD         0
 #endif // !AD_CFG_DISABLE_ADI_BYTE_SWAP_PD

--- a/src/abcc_api_config.h
+++ b/src/abcc_api_config.h
@@ -241,6 +241,18 @@
 ** AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 **   Disables swapping for both channels at once. Overrides the other two
 **   defines when set (simplifies configuration & reduces code size).
+**
+** note: Disabling swapping for message-based access will also disable min/max
+**       range checks for Set operations targeting ADI elements, since the
+**       application data object handler will no longer be able to determine the
+**       correct min/max values for the ADI elements (their byte order may
+**       differ from application byte order).
+**       To handle the range check within application, transparent set callbacks
+**       (enabled by ABCC_CFG_ADI_TRANS_SET_CALLBACK_ENABLED) can be used.
+**       The corresponding warning will be reported as plattform-independant
+**       compiler error but can be suppressed by defining
+**       AD_CFG_OVERRIDE_WARNING_RANGE_CHECK.
+** 
 */
 #ifndef AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
    #define AD_CFG_DISABLE_ADI_BYTE_SWAP_PD         0
@@ -260,5 +272,21 @@
    #undef AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
    #define AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE    0
 #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
+
+#ifndef AD_CFG_OVERRIDE_WARNING_RANGE_CHECK
+   #define AD_CFG_OVERRIDE_WARNING_RANGE_CHECK 0
+#endif // !AD_CFG_OVERRIDE_WARNING_RANGE_CHECK
+
+#if( AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL )
+   #if AD_IA_MIN_MAX_DEFAULT_ENABLE
+      #if !ABCC_CFG_ADI_TRANS_SET_CALLBACK_ENABLED
+         #if !AD_CFG_OVERRIDE_WARNING_RANGE_CHECK
+         
+            #error "WARNING: Range check (for message-based set accesses) does not work if ADI byte swap is disabled for message-based access. This warning can be overridden using the `AD_CFG_OVERRIDE_WARNING_RANGE_CHECK` define."
+         
+         #endif // !AD_CFG_OVERRIDE_WARNING_RANGE_CHECK
+      #endif // !ABCC_CFG_ADI_TRANS_SET_CALLBACK_ENABLED
+   #endif // AD_IA_MIN_MAX_DEFAULT_ENABLE
+#endif
 
 #endif

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -880,8 +880,8 @@ static UINT16 CopyBitData( void* pxDest,
 /*------------------------------------------------------------------------------
 **  Copy value (single element or parts of an array) of a specific type
 **  from a specified source to a destination. If the host platform endian
-**  differs from network endian a swap will be done (depending on
-**  configuration).
+**  differs from network endian a swap will be done if not disabled (see note 2
+**  below).
 **
 **  NOTE 1 !! For all non-bit data types the source and destination must be
 **  octet aligned.
@@ -889,7 +889,7 @@ static UINT16 CopyBitData( void* pxDest,
 **  NOTE 2 !! The defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD,
 **  AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 **  can be used to disable the byte swap functionality for process data, message
-**  data or both respectively. If AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL is set to
+**  data or both, respectively. If AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL is set to
 **  1, the other two defines are ignored.
 **------------------------------------------------------------------------------
 ** Arguments:
@@ -898,12 +898,12 @@ static UINT16 CopyBitData( void* pxDest,
 **    pxSrc             - Source base pointer.
 **    iSrcBitOffset     - Bit offset relative source pointer.
 **    bDataType         - Data type according to ABP_<X> types in abp.h
-**    iNumElem          - Number of elements to copy
+**    iNumElem          - Number of elements to copy.
 **
-**    fExplicit         - only present if AD_CFG_DISABLE_ADI_BYTE_SWAP_PD or
-**                        AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE is set to 1;
-**                        TRUE:  copy is triggered by a message
-**                        FALSE: copy is triggered by process data
+**    fExplicit         - Only present if AD_CFG_DISABLE_ADI_BYTE_SWAP_PD or
+**                        AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE is set to 1.
+**                        TRUE:  Copy is triggered by a message
+**                        FALSE: Copy is triggered by process data
 **
 ** Returns:
 **    Size of copied data in bits.
@@ -1115,7 +1115,13 @@ const ad_AllPropertiesType* GetDefaultProperties( UINT8 bDataType )
 
 /*------------------------------------------------------------------------------
 **  Get min, max or default value of a single ADI element.
-**  The value is converted to network endian (based on configuration).
+**  The value is converted to network endian if not disabled (see note below).
+**
+**  NOTE !! The defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD,
+**  AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
+**  can be used to disable the byte swap functionality for process data, message
+**  data or both, respectively. If AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL is set to
+**  1, the other two defines are ignored.
 **------------------------------------------------------------------------------
 ** Arguments:
 **    psAdiEntry        - Entry of ADI
@@ -1155,7 +1161,7 @@ static UINT16 GetSingleMinMaxDefault( const ad_AllPropertiesType* puProps,
                          bDataType,
                          1
               #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
-                       , TRUE // min/max/default are read by message based access, only
+                       , TRUE // min/max/default are read by message-based access, only
               #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                        );
 
@@ -1605,7 +1611,13 @@ static UINT8 GetMinMaxDefault( const AD_AdiEntryType* psAdiEntry,
 /*------------------------------------------------------------------------------
 **  Set ADI of any data type. The provided data must have network endian format.
 **  By default it is swapped to application byte order. This swap can be
-**  disabled by configuration.
+**  disabled by configuration (see note below).
+**
+**  NOTE !! The defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD,
+**  AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
+**  can be used to disable the byte swap functionality for process data, message
+**  data or both, respectively. If AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL is set to
+**  1, the other two defines are ignored.
 **------------------------------------------------------------------------------
 ** Arguments:
 **    psAdiEntry        - Pointer to ADI entry.

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -876,8 +876,15 @@ static UINT16 CopyBitData( void* pxDest,
 **  Copy value (single element or parts of an array) of a specific type
 **  from a specified source to a destination. If the host platform endian
 **  differs from network endian a swap will be done.
-**  NOTE!! For all non-bit data types the source and destination must be octet
-**  aligned.
+**
+**  NOTE 1 !! For all non-bit data types the source and destination must be
+**  octet aligned.
+**
+**  NOTE 2 !! The defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD, 
+**  AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
+**  can be used to disable the byte swap functionality for process data, message
+**  data or both respectively. If AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL is defined
+**  the other two defines are ignored.
 **------------------------------------------------------------------------------
 ** Arguments:
 **    pxDst             - Destination base pointer.
@@ -1142,7 +1149,7 @@ static UINT16 GetSingleMinMaxDefault( const ad_AllPropertiesType* puProps,
                          bDataType,
                          1
               #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
-                       , TRUE // range check is done for message based access, only
+                       , TRUE // min/max/default are read by message based access, only
               #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                        );
 

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -875,7 +875,8 @@ static UINT16 CopyBitData( void* pxDest,
 /*------------------------------------------------------------------------------
 **  Copy value (single element or parts of an array) of a specific type
 **  from a specified source to a destination. If the host platform endian
-**  differs from network endian a swap will be done.
+**  differs from network endian a swap will be done (depending on
+**  configuration).
 **
 **  NOTE 1 !! For all non-bit data types the source and destination must be
 **  octet aligned.

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -28,9 +28,6 @@
 #endif
 
 /*
-* test-Kommentar
-*/
-/*
 ** Value used in ad_MapType as ADI index when ADI 0 is mapped.
 */
 #define AD_MAP_PAD_INDEX                     ( 0xfffe )

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -1126,7 +1126,7 @@ const ad_AllPropertiesType* GetDefaultProperties( UINT8 bDataType )
 ** Arguments:
 **    psAdiEntry        - Entry of ADI
 **    pxDest            - Pointer to destination
-**    pxDest            - Destination bit offset
+**    iDestBitOffset    - Destination bit offset
 **    eMinMaxDefault    - Get min, max or default value described by
 **                        AD_MinMaxDefaultIndexType
 **    bDataType         - Data type

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -125,7 +125,7 @@ ad_MapInfoType;
 
 #if !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 static BOOL ad_fDoNetworkEndianSwap = FALSE;
-#endif // !AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
+#endif // !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 static const AD_MapType* ad_asDefaultMap = NULL;
 static const AD_AdiEntryType* ad_asADIEntryList = NULL;
 static UINT16  ad_iNumOfADIs;
@@ -2879,9 +2879,9 @@ void AD_WritePdMapFromBuffer( const AD_MapType* pasMap,
 UINT16 AD_AdiMappingReq( const AD_AdiEntryType** ppsAdiEntry,
                          const AD_MapType** ppsDefaultMap )
 {
+#if !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
    ABCC_NetFormatType eNetFormat;
    eNetFormat = ABCC_NetFormat();
-#if !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 #ifdef ABCC_SYS_BIG_ENDIAN
    ad_fDoNetworkEndianSwap = ( eNetFormat == NET_LITTLEENDIAN ) ? TRUE : FALSE;
 #else

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -1115,7 +1115,7 @@ const ad_AllPropertiesType* GetDefaultProperties( UINT8 bDataType )
 
 /*------------------------------------------------------------------------------
 **  Get min, max or default value of a single ADI element.
-**  The value is converted to network endian.
+**  The value is converted to network endian (based on configuration).
 **------------------------------------------------------------------------------
 ** Arguments:
 **    psAdiEntry        - Entry of ADI
@@ -1604,6 +1604,8 @@ static UINT8 GetMinMaxDefault( const AD_AdiEntryType* psAdiEntry,
 
 /*------------------------------------------------------------------------------
 **  Set ADI of any data type. The provided data must have network endian format.
+**  Dy default it is swapped to application byte order. This swap can be
+**  disabled by configuration.
 **------------------------------------------------------------------------------
 ** Arguments:
 **    psAdiEntry        - Pointer to ADI entry.

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -900,7 +900,7 @@ static UINT16 CopyBitData( void* pxDest,
 **    bDataType         - Data type according to ABP_<X> types in abp.h
 **    iNumElem          - Number of elements to copy
 **
-**    fExplicit         - only present if AD_CFG_DISABLE_ADI_BYTE_SWAP_PD or 
+**    fExplicit         - only present if AD_CFG_DISABLE_ADI_BYTE_SWAP_PD or
 **                        AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE is set to 1;
 **                        TRUE:  copy is triggered by a message
 **                        FALSE: copy is triggered by process data

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -880,11 +880,11 @@ static UINT16 CopyBitData( void* pxDest,
 **  NOTE 1 !! For all non-bit data types the source and destination must be
 **  octet aligned.
 **
-**  NOTE 2 !! The defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD, 
+**  NOTE 2 !! The defines AD_CFG_DISABLE_ADI_BYTE_SWAP_PD,
 **  AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE and AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 **  can be used to disable the byte swap functionality for process data, message
-**  data or both respectively. If AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL is defined
-**  the other two defines are ignored.
+**  data or both respectively. If AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL is set to
+**  1, the other two defines are ignored.
 **------------------------------------------------------------------------------
 ** Arguments:
 **    pxDst             - Destination base pointer.
@@ -895,7 +895,7 @@ static UINT16 CopyBitData( void* pxDest,
 **    iNumElem          - Number of elements to copy
 **
 **    fExplicit         - only present if AD_CFG_DISABLE_ADI_BYTE_SWAP_PD or 
-**                        AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE is defined;
+**                        AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE is set to 1;
 **                        TRUE:  copy is triggered by a message
 **                        FALSE: copy is triggered by process data
 **

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -888,21 +888,45 @@ static UINT16 CopyBitData( void* pxDest,
 **    pxSrc             - Source base pointer.
 **    iSrcBitOffset     - Bit offset relative source pointer.
 **    bDataType         - Data type according to ABP_<X> types in abp.h
-**    iNumElem          - Number of elements to copy.
+**    iNumElem          - Number of elements to copy
+**
+**    fExplicit         - only present if AD_CFG_DIABLE_BYTE_SWAP_PD or 
+**                        AD_CFG_DIABLE_BYTE_SWAP_MESSAGE is defined;
+**                        TRUE:  copy is triggered by a message
+**                        FALSE: copy is triggered by process data
 **
 ** Returns:
 **    Size of copied data in bits.
 **------------------------------------------------------------------------------
 */
-static UINT16 CopyValue( void* pxDst,
-                         UINT16 iDestBitOffset,
-                         const void* pxSrc,
-                         UINT16 iSrcBitOffset,
-                         UINT8 bDataType,
-                         UINT16 iNumElem )
+#if AD_CFG_DIABLE_BYTE_SWAP_PD || AD_CFG_DIABLE_BYTE_SWAP_MESSAGE
+   static UINT16 CopyValue( void* pxDst,
+                            UINT16 iDestBitOffset,
+                            const void* pxSrc,
+                            UINT16 iSrcBitOffset,
+                            UINT8 bDataType,
+                            UINT16 iNumElem,
+                            BOOL fExplicit )
+#else
+   static UINT16 CopyValue( void* pxDst,
+                            UINT16 iDestBitOffset,
+                            const void* pxSrc,
+                            UINT16 iSrcBitOffset,
+                            UINT8 bDataType,
+                            UINT16 iNumElem )
+#endif // AD_CFG_DIABLE_BYTE_SWAP_PD || AD_CFG_DIABLE_BYTE_SWAP_MESSAGE
 {
    UINT8 bDataTypeSizeInOctets;
    UINT16 iBitSetSize;
+   BOOL fDoNetworkEndianSwap = ad_fDoNetworkEndianSwap;
+#if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+   if( ( fExplicit && AD_CFG_DIABLE_BYTE_SWAP_MESSAGE ) ||
+       ( !fExplicit && AD_CFG_DIABLE_BYTE_SWAP_PD ) )
+   {
+      fDoNetworkEndianSwap = FALSE;
+   }
+#endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+
 
    if( Is_BITx_Or_PADx( bDataType ) || ( bDataType == ABP_BOOL1 ) )
    {
@@ -917,7 +941,8 @@ static UINT16 CopyValue( void* pxDst,
    {
       bDataTypeSizeInOctets = ABCC_GetDataTypeSize( bDataType );
 
-      if( ad_fDoNetworkEndianSwap )
+   #if !AD_CFG_DIABLE_BYTE_SWAP_TOTAL
+      if( fDoNetworkEndianSwap )
       {
          switch( bDataTypeSizeInOctets )
          {
@@ -951,6 +976,7 @@ static UINT16 CopyValue( void* pxDst,
          }
       }
       else
+   #endif // AD_CFG_DIABLE_BYTE_SWAP_TOTAL
       {
          ABCC_PORT_CopyOctets( pxDst, BitToOctetOffset( iDestBitOffset ),
                                pxSrc, BitToOctetOffset( iSrcBitOffset ),
@@ -1114,7 +1140,11 @@ static UINT16 GetSingleMinMaxDefault( const ad_AllPropertiesType* puProps,
                          puProps,
                          iSrcOctetOffset * 8,
                          bDataType,
-                         1 );
+                         1
+              #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                       , TRUE // range check is done for message based access, only
+              #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                       );
 
    return( iBitSize );
 }
@@ -1383,7 +1413,11 @@ static UINT8 VerifyRange( const AD_AdiEntryType* psAdiEntry, void* pxSrc, UINT16
                                            pxSrc,
                                            iSrcBitOffset,
                                            psAdiEntry->psStruct[ i ].bDataType,
-                                           1 );
+                                           1
+                                #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                         , TRUE // range check is done for message based access, only
+                                #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                         );
 
                bErrCode = checkMinMax( &uValue,
                                        psAdiEntry->psStruct[ i ].uData.sVOID.pxValueProps,
@@ -1418,7 +1452,11 @@ static UINT8 VerifyRange( const AD_AdiEntryType* psAdiEntry, void* pxSrc, UINT16
                                         pxSrc,
                                         iSrcBitOffset,
                                         psAdiEntry->bDataType,
-                                        1 );
+                                        1
+                             #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                      , TRUE // range check is done for message based access, only
+                             #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                      );
 
             bErrCode = checkMinMax( &uValue,
                                     psAdiEntry->uData.sVOID.pxValueProps,
@@ -1603,11 +1641,15 @@ static void SetAdiValue( const AD_AdiEntryType* psAdiEntry,
                                        pxData,
                                        *piSrcBitOffset,
                                        psAdiEntry->psStruct[ i ].bDataType,
-                                       psAdiEntry->psStruct[ i ].iNumSubElem );
+                                       psAdiEntry->psStruct[ i ].iNumSubElem
+                            #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                     , fExplicit
+                            #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                      );
       }
    }
    else
-#else
+#elif !(AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD)
    (void)fExplicit;
 #endif
    {
@@ -1617,7 +1659,11 @@ static void SetAdiValue( const AD_AdiEntryType* psAdiEntry,
                                     pxData,
                                     *piSrcBitOffset,
                                     psAdiEntry->bDataType,
-                                    bNumElements );
+                                    bNumElements
+                         #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                  , fExplicit
+                         #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                  );
    }
 #if( ABCC_CFG_ADI_GET_SET_CALLBACK_ENABLED )
    if( psAdiEntry->pnSetAdiValue != NULL )
@@ -2904,7 +2950,11 @@ void AD_GetAdiValue( const AD_AdiEntryType* psAdiEntry,
                                            psAdiEntry->psStruct[ i ].uData.sVOID.pxValuePtr,
                                            iSrcBitOffset,
                                            psAdiEntry->psStruct[ i ].bDataType,
-                                           psAdiEntry->psStruct[ i ].iNumSubElem );
+                                           psAdiEntry->psStruct[ i ].iNumSubElem
+                                #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                         , fExplicit
+                                #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                         );
          }
       }
       else
@@ -2917,12 +2967,16 @@ void AD_GetAdiValue( const AD_AdiEntryType* psAdiEntry,
                                            psAdiEntry->psStruct[ i ].uData.sVOID.pxValuePtr,
                                            iSrcBitOffset,
                                            psAdiEntry->psStruct[ i ].bDataType,
-                                           psAdiEntry->psStruct[ i ].iNumSubElem );
+                                           psAdiEntry->psStruct[ i ].iNumSubElem
+                                #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                         , fExplicit
+                                #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                         );
          }
       }
    }
    else
-#else
+#elif !(AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD)
    (void)fExplicit;
 #endif
    {
@@ -2932,7 +2986,11 @@ void AD_GetAdiValue( const AD_AdiEntryType* psAdiEntry,
                                      psAdiEntry->uData.sVOID.pxValuePtr,
                                      iSrcBitOffset,
                                      psAdiEntry->bDataType,
-                                     bNumElements );
+                                     bNumElements
+                          #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                   , fExplicit
+                          #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                   );
    }
 }
 

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -1161,7 +1161,7 @@ static UINT16 GetSingleMinMaxDefault( const ad_AllPropertiesType* puProps,
                          bDataType,
                          1
               #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
-                       , TRUE // min/max/default are read by message-based access, only
+                       , TRUE // min/max/default values of ADIs are read by message-based access, only
               #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                        );
 
@@ -1434,7 +1434,7 @@ static UINT8 VerifyRange( const AD_AdiEntryType* psAdiEntry, void* pxSrc, UINT16
                                            psAdiEntry->psStruct[ i ].bDataType,
                                            1
                                 #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
-                                         , TRUE // range check is done for message based access, only
+                                         , TRUE // range check is done for message based ADI access, only
                                 #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                          );
 
@@ -1473,7 +1473,7 @@ static UINT8 VerifyRange( const AD_AdiEntryType* psAdiEntry, void* pxSrc, UINT16
                                         psAdiEntry->bDataType,
                                         1
                              #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
-                                      , TRUE // range check is done for message based access, only
+                                      , TRUE // range check is done for message based ADI access, only
                              #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                       );
 

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -1604,7 +1604,7 @@ static UINT8 GetMinMaxDefault( const AD_AdiEntryType* psAdiEntry,
 
 /*------------------------------------------------------------------------------
 **  Set ADI of any data type. The provided data must have network endian format.
-**  Dy default it is swapped to application byte order. This swap can be
+**  By default it is swapped to application byte order. This swap can be
 **  disabled by configuration.
 **------------------------------------------------------------------------------
 ** Arguments:

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -887,8 +887,8 @@ static UINT16 CopyBitData( void* pxDest,
 **    bDataType         - Data type according to ABP_<X> types in abp.h
 **    iNumElem          - Number of elements to copy
 **
-**    fExplicit         - only present if AD_CFG_DIABLE_BYTE_SWAP_PD or 
-**                        AD_CFG_DIABLE_BYTE_SWAP_MESSAGE is defined;
+**    fExplicit         - only present if AD_CFG_DISABLE_ADI_BYTE_SWAP_PD or 
+**                        AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE is defined;
 **                        TRUE:  copy is triggered by a message
 **                        FALSE: copy is triggered by process data
 **
@@ -896,7 +896,7 @@ static UINT16 CopyBitData( void* pxDest,
 **    Size of copied data in bits.
 **------------------------------------------------------------------------------
 */
-#if AD_CFG_DIABLE_BYTE_SWAP_PD || AD_CFG_DIABLE_BYTE_SWAP_MESSAGE
+#if AD_CFG_DISABLE_ADI_BYTE_SWAP_PD || AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
    static UINT16 CopyValue( void* pxDst,
                             UINT16 iDestBitOffset,
                             const void* pxSrc,
@@ -911,18 +911,21 @@ static UINT16 CopyBitData( void* pxDest,
                             UINT16 iSrcBitOffset,
                             UINT8 bDataType,
                             UINT16 iNumElem )
-#endif // AD_CFG_DIABLE_BYTE_SWAP_PD || AD_CFG_DIABLE_BYTE_SWAP_MESSAGE
+#endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_PD || AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
 {
    UINT8 bDataTypeSizeInOctets;
    UINT16 iBitSetSize;
+#if !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
    BOOL fDoNetworkEndianSwap = ad_fDoNetworkEndianSwap;
-#if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
-   if( ( fExplicit && AD_CFG_DIABLE_BYTE_SWAP_MESSAGE ) ||
-       ( !fExplicit && AD_CFG_DIABLE_BYTE_SWAP_PD ) )
+#endif // !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
+
+#if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
+   if( ( fExplicit && AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE ) ||
+       ( !fExplicit && AD_CFG_DISABLE_ADI_BYTE_SWAP_PD ) )
    {
       fDoNetworkEndianSwap = FALSE;
    }
-#endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+#endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
 
 
    if( Is_BITx_Or_PADx( bDataType ) || ( bDataType == ABP_BOOL1 ) )
@@ -938,7 +941,7 @@ static UINT16 CopyBitData( void* pxDest,
    {
       bDataTypeSizeInOctets = ABCC_GetDataTypeSize( bDataType );
 
-   #if !AD_CFG_DIABLE_BYTE_SWAP_TOTAL
+   #if !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
       if( fDoNetworkEndianSwap )
       {
          switch( bDataTypeSizeInOctets )
@@ -973,7 +976,7 @@ static UINT16 CopyBitData( void* pxDest,
          }
       }
       else
-   #endif // AD_CFG_DIABLE_BYTE_SWAP_TOTAL
+   #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
       {
          ABCC_PORT_CopyOctets( pxDst, BitToOctetOffset( iDestBitOffset ),
                                pxSrc, BitToOctetOffset( iSrcBitOffset ),
@@ -1138,9 +1141,9 @@ static UINT16 GetSingleMinMaxDefault( const ad_AllPropertiesType* puProps,
                          iSrcOctetOffset * 8,
                          bDataType,
                          1
-              #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+              #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                        , TRUE // range check is done for message based access, only
-              #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+              #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                        );
 
    return( iBitSize );
@@ -1411,9 +1414,9 @@ static UINT8 VerifyRange( const AD_AdiEntryType* psAdiEntry, void* pxSrc, UINT16
                                            iSrcBitOffset,
                                            psAdiEntry->psStruct[ i ].bDataType,
                                            1
-                                #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                          , TRUE // range check is done for message based access, only
-                                #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                          );
 
                bErrCode = checkMinMax( &uValue,
@@ -1450,9 +1453,9 @@ static UINT8 VerifyRange( const AD_AdiEntryType* psAdiEntry, void* pxSrc, UINT16
                                         iSrcBitOffset,
                                         psAdiEntry->bDataType,
                                         1
-                             #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                             #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                       , TRUE // range check is done for message based access, only
-                             #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                             #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                       );
 
             bErrCode = checkMinMax( &uValue,
@@ -1639,14 +1642,14 @@ static void SetAdiValue( const AD_AdiEntryType* psAdiEntry,
                                        *piSrcBitOffset,
                                        psAdiEntry->psStruct[ i ].bDataType,
                                        psAdiEntry->psStruct[ i ].iNumSubElem
-                            #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                            #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                      , fExplicit
-                            #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                            #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                       );
       }
    }
    else
-#elif !(AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD)
+#elif !(AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD)
    (void)fExplicit;
 #endif
    {
@@ -1657,9 +1660,9 @@ static void SetAdiValue( const AD_AdiEntryType* psAdiEntry,
                                     *piSrcBitOffset,
                                     psAdiEntry->bDataType,
                                     bNumElements
-                         #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                         #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                   , fExplicit
-                         #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                         #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                   );
    }
 #if( ABCC_CFG_ADI_GET_SET_CALLBACK_ENABLED )
@@ -2948,9 +2951,9 @@ void AD_GetAdiValue( const AD_AdiEntryType* psAdiEntry,
                                            iSrcBitOffset,
                                            psAdiEntry->psStruct[ i ].bDataType,
                                            psAdiEntry->psStruct[ i ].iNumSubElem
-                                #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                          , fExplicit
-                                #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                          );
          }
       }
@@ -2965,15 +2968,15 @@ void AD_GetAdiValue( const AD_AdiEntryType* psAdiEntry,
                                            iSrcBitOffset,
                                            psAdiEntry->psStruct[ i ].bDataType,
                                            psAdiEntry->psStruct[ i ].iNumSubElem
-                                #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                          , fExplicit
-                                #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                                #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                          );
          }
       }
    }
    else
-#elif !(AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD)
+#elif !(AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD)
    (void)fExplicit;
 #endif
    {
@@ -2984,9 +2987,9 @@ void AD_GetAdiValue( const AD_AdiEntryType* psAdiEntry,
                                      iSrcBitOffset,
                                      psAdiEntry->bDataType,
                                      bNumElements
-                          #if AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                          #if AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                    , fExplicit
-                          #endif // AD_CFG_DIABLE_BYTE_SWAP_MESSAGE || AD_CFG_DIABLE_BYTE_SWAP_PD
+                          #endif // AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
                                    );
    }
 }

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -28,6 +28,9 @@
 #endif
 
 /*
+* test-Kommentar
+*/
+/*
 ** Value used in ad_MapType as ADI index when ADI 0 is mapped.
 */
 #define AD_MAP_PAD_INDEX                     ( 0xfffe )

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -123,7 +123,9 @@ typedef struct ad_MapInfo
 }
 ad_MapInfoType;
 
+#if !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 static BOOL ad_fDoNetworkEndianSwap = FALSE;
+#endif // !AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE
 static const AD_MapType* ad_asDefaultMap = NULL;
 static const AD_AdiEntryType* ad_asADIEntryList = NULL;
 static UINT16  ad_iNumOfADIs;
@@ -199,6 +201,7 @@ while( 0 )
 */
 #define BitToOctetOffset( bitOffset ) ( (bitOffset) >> 3 )
 
+#if !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 /*------------------------------------------------------------------------------
 ** Copies a 16 bit values from a source to a destination. Each value will be
 ** endian swapped. The function support octet alignment.
@@ -294,6 +297,8 @@ static void Copy64WithEndianSwap( void* pxDest, UINT16 iDestOctetOffset,
    }
 }
 #endif
+
+#endif // !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 
 /*------------------------------------------------------------------------------
 ** Calculates the size of a part of or a complete ADI, in bits.
@@ -2876,11 +2881,13 @@ UINT16 AD_AdiMappingReq( const AD_AdiEntryType** ppsAdiEntry,
 {
    ABCC_NetFormatType eNetFormat;
    eNetFormat = ABCC_NetFormat();
+#if !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 #ifdef ABCC_SYS_BIG_ENDIAN
    ad_fDoNetworkEndianSwap = ( eNetFormat == NET_LITTLEENDIAN ) ? TRUE : FALSE;
 #else
    ad_fDoNetworkEndianSwap = ( eNetFormat == NET_LITTLEENDIAN ) ? FALSE : TRUE;
 #endif
+#endif // !AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL
 
    *ppsAdiEntry = ad_asADIEntryList;
    *ppsDefaultMap = ad_asDefaultMap;

--- a/src/host_objects/application_data_object.c
+++ b/src/host_objects/application_data_object.c
@@ -2480,8 +2480,12 @@ void AD_ProcObjectRequest( ABP_MsgType* psMsgBuffer )
                break;
             }
 #if( AD_IA_MIN_MAX_DEFAULT_ENABLE )
+   #if !( AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL )
+
             bErrCode = VerifyRange( psAdiEntry, ABCC_GetMsgDataPtr( psMsgBuffer ),
                                     AD_ALL_ADI_INDEX );
+
+   #endif // !( AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL )
 #endif
 
             if( bErrCode == ABP_ERR_NO_ERROR )
@@ -2674,8 +2678,12 @@ void AD_ProcObjectRequest( ABP_MsgType* psMsgBuffer )
                   }
 
 #if( AD_IA_MIN_MAX_DEFAULT_ENABLE )
+   #if !( AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL )
+
                   bErrCode = VerifyRange( psAdiEntry, ABCC_GetMsgDataPtr( psMsgBuffer ),
                                           ABCC_GetMsgCmdExt1( psMsgBuffer ) );
+
+   #endif // !( AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE || AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL )
 #endif
                   if( bErrCode == ABP_ERR_NO_ERROR )
                   {


### PR DESCRIPTION
For applications where the process data structure is defined in the field, arrays are often used to implement generic device description files.
If (for longer data lengths) arrays of larger data types are used instead of UINT8 arrays, the API’s internal swapping can corrupt the process data because it is unaware of the internal structure of the data blocks.
If the byte order of parameters shall be configurable on application side, it should be possible to disable automatic swapping for message based access, too.
In this case, the corresponding define has to affect access to min- max- and default-value, too.

=> at least two defines are needed:
  AD_CFG_DISABLE_ADI_BYTE_SWAP_PD
and
  AD_CFG_DISABLE_ADI_BYTE_SWAP_MESSAGE

As code size can be reduced if swapping is disabled completely, A third define was added:
  AD_CFG_DISABLE_ADI_BYTE_SWAP_TOTAL